### PR TITLE
Ignition 3.6 has been stabilized

### DIFF
--- a/.github/workflows/build-ignition-image.yml
+++ b/.github/workflows/build-ignition-image.yml
@@ -3,7 +3,7 @@ name: "Build and push Ignition container image"
 env:
   NAME: "ignition"
   REGISTRY: "quay.io/trusted-execution-clusters"
-  COMMIT: "5a45ee84"
+  COMMIT: "af7bcce09"
 
 on:
   push:


### PR DESCRIPTION
Stop building ignition before the stabilization and start using 3.6 instead of 3.6-experimental.
The commit includes the stabilization of ignition 3.6: https://github.com/coreos/ignition/pull/2202
